### PR TITLE
Use registerTwigExtension()

### DIFF
--- a/src/Parsedown.php
+++ b/src/Parsedown.php
@@ -76,8 +76,8 @@ class Parsedown extends Plugin
 		]);
 
 		// Add in our Twig extensions
-		Craft::$app->view->twig->addExtension(new ParsedownTwigExtension());
-		Craft::$app->view->twig->addExtension(new ParsedownExtraTwigExtension());
+		Craft::$app->view->registerTwigExtension(new ParsedownTwigExtension());
+		Craft::$app->view->registerTwigExtension(new ParsedownExtraTwigExtension());
 
 		// Do something after we're installed
 		Event::on(


### PR DESCRIPTION
Fixes a bug where the plugin may cause Twig to be loaded before it should be, and another bug where the extension might not be available if the Template Mode ever changes from CP to Site, or vise-versa.